### PR TITLE
Correct case of filename in #include directive

### DIFF
--- a/AutoWatering/AutoWatering.h
+++ b/AutoWatering/AutoWatering.h
@@ -15,7 +15,7 @@
 #ifndef AutoWatering_h
 #define AutoWatering_h
 #include <avr/eeprom.h>
-#include <arduino.h>
+#include <Arduino.h>
 
 #define addr  0
 


### PR DESCRIPTION
Incorrect capitalization of Arduino.h causes compilation to fail on case-sensitive file systems, as used by Linux.